### PR TITLE
fix(planner): enforce cool-off on funding & deficit sells

### DIFF
--- a/sentinel/jobs/tasks.py
+++ b/sentinel/jobs/tasks.py
@@ -254,6 +254,30 @@ async def sync_exchange_rates() -> None:
     logger.info(f"Exchange rates synced: {len(rates)} currencies")
 
 
+def _parse_broker_timestamp(date_str: str) -> int:
+    """Parse a broker trade date into a unix timestamp (0 if unparseable).
+
+    Tradernet/Freedom24 has used several date formats over time: ISO 8601 with a
+    'T' separator and milliseconds ("2026-06-03T11:46:14.640"), space-separated
+    ("2026-06-03 11:46:14"), and date-only ("2026-06-03"). The previous parser
+    only handled the space and date-only forms, so the current ISO form silently
+    collapsed to midnight and lost the intraday time. ``datetime.fromisoformat``
+    handles all of these (including a trailing 'Z'/offset); we fall back to the
+    date portion only if the full string can't be parsed.
+    """
+    if not isinstance(date_str, str) or not date_str.strip():
+        return 0
+    raw = date_str.strip()
+    try:
+        return int(datetime.fromisoformat(raw).timestamp())
+    except ValueError:
+        pass
+    try:
+        return int(datetime.strptime(raw[:10], "%Y-%m-%d").timestamp())
+    except (ValueError, TypeError):
+        return 0
+
+
 async def sync_trades(db, broker) -> None:
     """
     Sync trade history from broker.
@@ -313,15 +337,9 @@ async def sync_trades(db, broker) -> None:
         if not trade_id or not symbol:
             continue
 
-        # Parse broker date to unix timestamp (Tradernet: "YYYY-MM-DD HH:MM:SS" or "YYYY-MM-DD")
-        try:
-            if " " in date_str:
-                dt = datetime.strptime(date_str, "%Y-%m-%d %H:%M:%S")
-            else:
-                dt = datetime.strptime(date_str[:10], "%Y-%m-%d")
-            executed_at_ts = int(dt.timestamp())
-        except (ValueError, TypeError):
-            executed_at_ts = 0
+        # Parse broker date to unix timestamp. Handles ISO 8601 ("...T..."),
+        # space-separated, and date-only forms (see _parse_broker_timestamp).
+        executed_at_ts = _parse_broker_timestamp(date_str)
 
         row_id = await db.upsert_trade(
             broker_trade_id=trade_id,

--- a/sentinel/planner/rebalance_cash.py
+++ b/sentinel/planner/rebalance_cash.py
@@ -522,16 +522,18 @@ async def generate_deficit_sells(
     # Cool-off gating. This funding/deficit path builds sells directly and
     # historically skipped the cool-off check the main recommendation path
     # enforces, so the engine would sell names it had just bought to fund new
-    # buys (churn). Funding-rotation sells must respect cool-off outright;
-    # negative-balance repair prefers fresh names but may fall back to names
-    # still in their window as a last resort to avoid a margin-incurring deficit.
+    # buys (churn). A name still inside its cool-off window is simply not a good
+    # trade right now, so we drop it outright — for both funding rotation and
+    # negative-balance repair. We never demote it to a fallback tier: doing so
+    # could sell a perfectly good holding ahead of a worse one just to satisfy a
+    # cash constraint, which is itself a bad trade. If nothing eligible remains,
+    # we make no trade and let the next cycle (once the window expires) act.
     #
-    # We deliberately use the *core* window as the opposite-side bound for every
-    # funding sell (rather than per-sleeve): it's the more conservative of the
-    # configured windows, and over-blocking is safe in both branches — a rotation
-    # sell is simply skipped (we buy less), and a deficit sell is only deferred to
-    # the fallback tier, never dropped. The same-side window guards re-selling a
-    # name we recently sold, matching the main-path policy.
+    # The *core* window is used as the opposite-side bound for every funding
+    # sell (rather than per-sleeve): it's the more conservative of the configured
+    # windows, and over-blocking only ever means "trade less", never a bad trade.
+    # The same-side window guards re-selling a name we recently sold, matching
+    # the main-path policy.
     cooloff_days = int(await _setting(engine, "strategy_core_cooloff_days", 21))
     same_side_cooloff_days = int(await _setting(engine, "strategy_same_side_cooloff_days", 15))
     if position_data and (cooloff_days > 0 or same_side_cooloff_days > 0):
@@ -549,25 +551,13 @@ async def generate_deficit_sells(
             if is_blocked:
                 blocked_symbols.add(pos["symbol"])
         if blocked_symbols:
-            if reason_kind == "funding_rotation":
-                # Never churn: drop names still inside their cool-off window.
-                position_data = [p for p in position_data if p["symbol"] not in blocked_symbols]
-                logger.debug(
-                    "Cool-off suppressed %d funding-rotation sell candidate(s): %s",
-                    len(blocked_symbols),
-                    sorted(blocked_symbols),
-                )
-            else:
-                # Negative-balance repair: exhaust fresh names first, then fall
-                # back to cool-off names only if the deficit still isn't covered.
-                position_data = [p for p in position_data if p["symbol"] not in blocked_symbols] + [
-                    p for p in position_data if p["symbol"] in blocked_symbols
-                ]
-                logger.debug(
-                    "Cool-off deprioritized %d deficit-repair sell candidate(s) to fallback: %s",
-                    len(blocked_symbols),
-                    sorted(blocked_symbols),
-                )
+            position_data = [p for p in position_data if p["symbol"] not in blocked_symbols]
+            logger.debug(
+                "Cool-off suppressed %d %s sell candidate(s): %s",
+                len(blocked_symbols),
+                reason_kind,
+                sorted(blocked_symbols),
+            )
 
     for pos in position_data:
         if remaining_deficit <= 0:

--- a/sentinel/planner/rebalance_cash.py
+++ b/sentinel/planner/rebalance_cash.py
@@ -26,6 +26,24 @@ async def _setting(engine: "RebalanceEngine", key: str, default: float | int) ->
     return default if value is None else value
 
 
+async def _load_latest_trades(engine: "RebalanceEngine", symbols: list[str]) -> dict[str, dict]:
+    """Best-effort latest-trade-per-symbol lookup for cool-off gating.
+
+    Returns an empty map when the backing db doesn't expose the bulk getter
+    (e.g. mocked engines in unit tests), in which case cool-off gating is a
+    no-op and the caller falls back to its prior behaviour.
+    """
+    getter = getattr(engine._db, "get_latest_trades_for_symbols", None)
+    if not callable(getter) or not symbols:
+        return {}
+    try:
+        maybe = getter(symbols)
+        result = await maybe if inspect.isawaitable(maybe) else maybe
+    except Exception:
+        return {}
+    return result if isinstance(result, dict) else {}
+
+
 async def apply_cash_constraint(
     *,
     engine: "RebalanceEngine",
@@ -497,6 +515,39 @@ async def generate_deficit_sells(
         total_value += sum(float(p["eur_value"]) for p in position_data)
     else:
         total_value = await engine._portfolio.total_value()
+
+    # Cool-off gating. This funding/deficit path builds sells directly and
+    # historically skipped the cool-off check the main recommendation path
+    # enforces, so the engine would sell names it had just bought to fund new
+    # buys (churn). Funding-rotation sells must respect cool-off outright;
+    # negative-balance repair prefers fresh names but may fall back to names
+    # still in their window as a last resort to avoid a margin-incurring deficit.
+    cooloff_days = int(await _setting(engine, "strategy_core_cooloff_days", 21))
+    same_side_cooloff_days = int(await _setting(engine, "strategy_same_side_cooloff_days", 15))
+    if position_data and (cooloff_days > 0 or same_side_cooloff_days > 0):
+        latest_trades = await _load_latest_trades(engine, [p["symbol"] for p in position_data])
+        blocked_symbols: set[str] = set()
+        for pos in position_data:
+            is_blocked, _ = await engine._check_cooloff_violation(
+                pos["symbol"],
+                "sell",
+                cooloff_days,
+                same_side_cooloff_days=same_side_cooloff_days,
+                latest_trade=latest_trades.get(pos["symbol"]),
+                as_of_date=as_of_date,
+            )
+            if is_blocked:
+                blocked_symbols.add(pos["symbol"])
+        if blocked_symbols:
+            if reason_kind == "funding_rotation":
+                # Never churn: drop names still inside their cool-off window.
+                position_data = [p for p in position_data if p["symbol"] not in blocked_symbols]
+            else:
+                # Negative-balance repair: exhaust fresh names first, then fall
+                # back to cool-off names only if the deficit still isn't covered.
+                position_data = [p for p in position_data if p["symbol"] not in blocked_symbols] + [
+                    p for p in position_data if p["symbol"] in blocked_symbols
+                ]
 
     for pos in position_data:
         if remaining_deficit <= 0:

--- a/sentinel/planner/rebalance_cash.py
+++ b/sentinel/planner/rebalance_cash.py
@@ -519,45 +519,51 @@ async def generate_deficit_sells(
     else:
         total_value = await engine._portfolio.total_value()
 
-    # Cool-off gating. This funding/deficit path builds sells directly and
-    # historically skipped the cool-off check the main recommendation path
-    # enforces, so the engine would sell names it had just bought to fund new
-    # buys (churn). A name still inside its cool-off window is simply not a good
-    # trade right now, so we drop it outright — for both funding rotation and
-    # negative-balance repair. We never demote it to a fallback tier: doing so
-    # could sell a perfectly good holding ahead of a worse one just to satisfy a
-    # cash constraint, which is itself a bad trade. If nothing eligible remains,
-    # we make no trade and let the next cycle (once the window expires) act.
+    # Cool-off gating for funding-rotation sells only.
     #
-    # The *core* window is used as the opposite-side bound for every funding
-    # sell (rather than per-sleeve): it's the more conservative of the configured
-    # windows, and over-blocking only ever means "trade less", never a bad trade.
-    # The same-side window guards re-selling a name we recently sold, matching
-    # the main-path policy.
-    cooloff_days = int(await _setting(engine, "strategy_core_cooloff_days", 21))
-    same_side_cooloff_days = int(await _setting(engine, "strategy_same_side_cooloff_days", 15))
-    if position_data and (cooloff_days > 0 or same_side_cooloff_days > 0):
-        latest_trades = await _load_latest_trades(engine, [p["symbol"] for p in position_data])
-        blocked_symbols: set[str] = set()
-        for pos in position_data:
-            is_blocked, _ = await engine._check_cooloff_violation(
-                pos["symbol"],
-                "sell",
-                cooloff_days,
-                same_side_cooloff_days=same_side_cooloff_days,
-                latest_trade=latest_trades.get(pos["symbol"]),
-                as_of_date=as_of_date,
-            )
-            if is_blocked:
-                blocked_symbols.add(pos["symbol"])
-        if blocked_symbols:
-            position_data = [p for p in position_data if p["symbol"] not in blocked_symbols]
-            logger.debug(
-                "Cool-off suppressed %d %s sell candidate(s): %s",
-                len(blocked_symbols),
-                reason_kind,
-                sorted(blocked_symbols),
-            )
+    # This path builds sells directly and historically skipped the cool-off
+    # check the main recommendation path enforces, letting the engine sell names
+    # it had just bought to fund new buys (churn). Funding-rotation sells raise
+    # cash for *optional* buys, so a name still inside its cool-off window is not
+    # a good sell: we drop it and simply buy less. We never demote it to a
+    # fallback tier — selling a good holding to satisfy a cash constraint is
+    # itself a bad trade. If nothing eligible remains, we make no trade and let a
+    # later cycle act once the window expires.
+    #
+    # Negative-balance repair (reason_kind="cash_deficit") is the one exception
+    # and is intentionally NOT gated here: a real negative cash balance accrues
+    # margin interest and must be covered. (Currency-only deficits are handled
+    # upstream by the trading:balance_fix FX-conversion job; this path only sells
+    # securities when an FX conversion can't cover the shortfall.)
+    #
+    # The *core* window is used as the opposite-side bound (rather than per-sleeve):
+    # it's the more conservative of the configured windows, and over-blocking only
+    # ever means "trade less", never a bad trade. The same-side window guards
+    # re-selling a name we recently sold, matching the main-path policy.
+    if reason_kind == "funding_rotation":
+        cooloff_days = int(await _setting(engine, "strategy_core_cooloff_days", 21))
+        same_side_cooloff_days = int(await _setting(engine, "strategy_same_side_cooloff_days", 15))
+        if position_data and (cooloff_days > 0 or same_side_cooloff_days > 0):
+            latest_trades = await _load_latest_trades(engine, [p["symbol"] for p in position_data])
+            blocked_symbols: set[str] = set()
+            for pos in position_data:
+                is_blocked, _ = await engine._check_cooloff_violation(
+                    pos["symbol"],
+                    "sell",
+                    cooloff_days,
+                    same_side_cooloff_days=same_side_cooloff_days,
+                    latest_trade=latest_trades.get(pos["symbol"]),
+                    as_of_date=as_of_date,
+                )
+                if is_blocked:
+                    blocked_symbols.add(pos["symbol"])
+            if blocked_symbols:
+                position_data = [p for p in position_data if p["symbol"] not in blocked_symbols]
+                logger.debug(
+                    "Cool-off suppressed %d funding-rotation sell candidate(s): %s",
+                    len(blocked_symbols),
+                    sorted(blocked_symbols),
+                )
 
     for pos in position_data:
         if remaining_deficit <= 0:

--- a/sentinel/planner/rebalance_cash.py
+++ b/sentinel/planner/rebalance_cash.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+import logging
 import math
 from dataclasses import replace
 from typing import TYPE_CHECKING
@@ -15,6 +16,8 @@ from .rebalance_rules import calculate_transaction_cost
 
 if TYPE_CHECKING:
     from .rebalance import RebalanceEngine
+
+logger = logging.getLogger(__name__)
 
 
 async def _setting(engine: "RebalanceEngine", key: str, default: float | int) -> float | int:
@@ -522,6 +525,13 @@ async def generate_deficit_sells(
     # buys (churn). Funding-rotation sells must respect cool-off outright;
     # negative-balance repair prefers fresh names but may fall back to names
     # still in their window as a last resort to avoid a margin-incurring deficit.
+    #
+    # We deliberately use the *core* window as the opposite-side bound for every
+    # funding sell (rather than per-sleeve): it's the more conservative of the
+    # configured windows, and over-blocking is safe in both branches — a rotation
+    # sell is simply skipped (we buy less), and a deficit sell is only deferred to
+    # the fallback tier, never dropped. The same-side window guards re-selling a
+    # name we recently sold, matching the main-path policy.
     cooloff_days = int(await _setting(engine, "strategy_core_cooloff_days", 21))
     same_side_cooloff_days = int(await _setting(engine, "strategy_same_side_cooloff_days", 15))
     if position_data and (cooloff_days > 0 or same_side_cooloff_days > 0):
@@ -542,12 +552,22 @@ async def generate_deficit_sells(
             if reason_kind == "funding_rotation":
                 # Never churn: drop names still inside their cool-off window.
                 position_data = [p for p in position_data if p["symbol"] not in blocked_symbols]
+                logger.debug(
+                    "Cool-off suppressed %d funding-rotation sell candidate(s): %s",
+                    len(blocked_symbols),
+                    sorted(blocked_symbols),
+                )
             else:
                 # Negative-balance repair: exhaust fresh names first, then fall
                 # back to cool-off names only if the deficit still isn't covered.
                 position_data = [p for p in position_data if p["symbol"] not in blocked_symbols] + [
                     p for p in position_data if p["symbol"] in blocked_symbols
                 ]
+                logger.debug(
+                    "Cool-off deprioritized %d deficit-repair sell candidate(s) to fallback: %s",
+                    len(blocked_symbols),
+                    sorted(blocked_symbols),
+                )
 
     for pos in position_data:
         if remaining_deficit <= 0:

--- a/tests/jobs/test_tasks.py
+++ b/tests/jobs/test_tasks.py
@@ -862,3 +862,59 @@ class TestBackupR2:
                                     mock_create.assert_called_once()
                                     mock_client.assert_called_once()
                                     mock_upload.assert_called_once()
+
+
+class TestParseBrokerTimestamp:
+    """Tests for _parse_broker_timestamp covering the broker date formats."""
+
+    def test_iso_with_t_and_milliseconds_preserves_time(self):
+        """The current Tradernet/Freedom24 ISO form keeps its intraday time."""
+        from datetime import datetime
+
+        from sentinel.jobs.tasks import _parse_broker_timestamp
+
+        ts = _parse_broker_timestamp("2026-06-03T11:46:14.640")
+        # Round-trips back to the same wall-clock instant (not midnight).
+        assert datetime.fromtimestamp(ts) == datetime(2026, 6, 3, 11, 46, 14)
+
+    def test_space_separated_form(self):
+        from datetime import datetime
+
+        from sentinel.jobs.tasks import _parse_broker_timestamp
+
+        ts = _parse_broker_timestamp("2026-06-03 11:46:14")
+        assert datetime.fromtimestamp(ts) == datetime(2026, 6, 3, 11, 46, 14)
+
+    def test_date_only_form(self):
+        from datetime import datetime
+
+        from sentinel.jobs.tasks import _parse_broker_timestamp
+
+        ts = _parse_broker_timestamp("2026-06-03")
+        assert datetime.fromtimestamp(ts) == datetime(2026, 6, 3, 0, 0, 0)
+
+    def test_iso_with_trailing_z_is_utc(self):
+        from datetime import datetime, timezone
+
+        from sentinel.jobs.tasks import _parse_broker_timestamp
+
+        ts = _parse_broker_timestamp("2026-06-03T11:46:14.640Z")
+        assert datetime.fromtimestamp(ts, tz=timezone.utc).replace(microsecond=0) == datetime(
+            2026, 6, 3, 11, 46, 14, tzinfo=timezone.utc
+        )
+
+    def test_garbage_with_valid_date_prefix_falls_back_to_date(self):
+        from datetime import datetime
+
+        from sentinel.jobs.tasks import _parse_broker_timestamp
+
+        ts = _parse_broker_timestamp("2026-06-03 not-a-time")
+        assert datetime.fromtimestamp(ts) == datetime(2026, 6, 3, 0, 0, 0)
+
+    def test_empty_or_invalid_returns_zero(self):
+        from sentinel.jobs.tasks import _parse_broker_timestamp
+
+        assert _parse_broker_timestamp("") == 0
+        assert _parse_broker_timestamp("   ") == 0
+        assert _parse_broker_timestamp("nonsense") == 0
+        assert _parse_broker_timestamp(None) == 0  # type: ignore[arg-type]

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -339,43 +339,36 @@ class TestDeficitSellsSimulatedCash:
         assert "STALE.EU" in sold
 
     @pytest.mark.asyncio
-    async def test_cash_deficit_repair_never_sells_cooloff_names(self):
-        """Negative-balance repair must not sell a cool-off name even if the deficit
-        isn't fully covered. A cool-off sell is a bad trade; better to leave a
-        residual deficit and let the next cycle act once the window expires."""
+    async def test_cash_deficit_repair_bypasses_cooloff(self):
+        """Negative-balance repair is the one flow that MUST bypass cool-off: a real
+        negative cash balance accrues margin interest and has to be covered, even when
+        the only sellable name was traded inside its cool-off window."""
         import time
 
         two_days_ago = int(time.time()) - 2 * 86400
+        # The sole holding was bought 2 days ago -> deep inside its cool-off window.
         engine = self._cooloff_engine({"FRESH.EU": {"side": "BUY", "executed_at": two_days_ago}})
 
         securities_map = {
             "FRESH.EU": {
                 "symbol": "FRESH.EU", "currency": "EUR", "min_lot": 1, "allow_sell": 1, "user_multiplier": 0.3,
             },
-            "STALE.EU": {
-                "symbol": "STALE.EU", "currency": "EUR", "min_lot": 1, "allow_sell": 1, "user_multiplier": 0.3,
-            },
         }
-        positions = [
-            {"symbol": "FRESH.EU", "quantity": 10, "current_price": 100.0},
-            {"symbol": "STALE.EU", "quantity": 10, "current_price": 100.0},
-        ]
+        positions = [{"symbol": "FRESH.EU", "quantity": 10, "current_price": 100.0}]
 
-        # Deficit larger than the one eligible position: the cool-off name must
-        # still never be sold to cover the remainder.
         sells = await engine._generate_deficit_sells(
-            1500.0,
+            500.0,
             reason_kind="cash_deficit",
             total_value=10000.0,
             preloaded_positions=positions,
             preloaded_securities_map=securities_map,
-            preloaded_symbol_scores={"FRESH.EU": 0.1, "STALE.EU": 0.1},
-            preloaded_symbol_prices={"FRESH.EU": 100.0, "STALE.EU": 100.0},
+            preloaded_symbol_scores={"FRESH.EU": 0.1},
+            preloaded_symbol_prices={"FRESH.EU": 100.0},
         )
 
         sold = {s.symbol for s in sells}
-        assert "FRESH.EU" not in sold  # cool-off name never sold, even under deficit
-        assert "STALE.EU" in sold  # only the eligible name is sold (partial repair)
+        # Cool-off is bypassed for negative-balance repair: the name is sold anyway.
+        assert "FRESH.EU" in sold
 
     @pytest.mark.asyncio
     async def test_funding_rotation_blocks_same_side_and_allows_untraded(self):

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -280,6 +280,99 @@ class TestDeficitSellsSimulatedCash:
         # Portfolio returns positive cash, so no deficit sells needed
         assert sells == []
 
+    @staticmethod
+    def _cooloff_engine(latest_trades: dict):
+        """Build an engine whose db exposes a recent-trade map and cool-off settings."""
+        db = MagicMock()
+        db.get_latest_trades_for_symbols = AsyncMock(return_value=latest_trades)
+        engine = RebalanceEngine(db=db)
+        engine._db = db
+        engine._currency = MagicMock()
+        engine._currency.to_eur = AsyncMock(side_effect=lambda amt, curr: amt)
+        engine._currency.get_rate = AsyncMock(return_value=1.0)
+        engine._settings = MagicMock()
+        engine._settings.get = AsyncMock(
+            side_effect=lambda key, default=None: {
+                "strategy_core_cooloff_days": 21,
+                "strategy_same_side_cooloff_days": 15,
+                "strategy_funding_conviction_bias": 1.0,
+            }.get(key, default)
+        )
+        return engine
+
+    @pytest.mark.asyncio
+    async def test_funding_rotation_skips_cooloff_names(self):
+        """Funding-rotation sells must not churn a name still inside its cool-off window."""
+        import time
+
+        two_days_ago = int(time.time()) - 2 * 86400
+        engine = self._cooloff_engine({"FRESH.EU": {"side": "BUY", "executed_at": two_days_ago}})
+
+        securities_map = {
+            "FRESH.EU": {
+                "symbol": "FRESH.EU", "currency": "EUR", "min_lot": 1, "allow_sell": 1, "user_multiplier": 0.3,
+            },
+            "STALE.EU": {
+                "symbol": "STALE.EU", "currency": "EUR", "min_lot": 1, "allow_sell": 1, "user_multiplier": 0.3,
+            },
+        }
+        positions = [
+            {"symbol": "FRESH.EU", "quantity": 10, "current_price": 100.0},
+            {"symbol": "STALE.EU", "quantity": 10, "current_price": 100.0},
+        ]
+
+        sells = await engine._generate_deficit_sells(
+            500.0,
+            reason_kind="funding_rotation",
+            total_value=10000.0,
+            preloaded_positions=positions,
+            preloaded_securities_map=securities_map,
+            preloaded_symbol_scores={"FRESH.EU": 0.1, "STALE.EU": 0.1},
+            preloaded_symbol_prices={"FRESH.EU": 100.0, "STALE.EU": 100.0},
+        )
+
+        sold = {s.symbol for s in sells}
+        # FRESH.EU was bought 2 days ago -> within 21-day core cool-off -> excluded.
+        assert "FRESH.EU" not in sold
+        assert "STALE.EU" in sold
+
+    @pytest.mark.asyncio
+    async def test_cash_deficit_repair_falls_back_to_cooloff_names(self):
+        """Negative-balance repair exhausts fresh names first, then falls back to cool-off names."""
+        import time
+
+        two_days_ago = int(time.time()) - 2 * 86400
+        engine = self._cooloff_engine({"FRESH.EU": {"side": "BUY", "executed_at": two_days_ago}})
+
+        securities_map = {
+            "FRESH.EU": {
+                "symbol": "FRESH.EU", "currency": "EUR", "min_lot": 1, "allow_sell": 1, "user_multiplier": 0.3,
+            },
+            "STALE.EU": {
+                "symbol": "STALE.EU", "currency": "EUR", "min_lot": 1, "allow_sell": 1, "user_multiplier": 0.3,
+            },
+        }
+        positions = [
+            {"symbol": "FRESH.EU", "quantity": 10, "current_price": 100.0},
+            {"symbol": "STALE.EU", "quantity": 10, "current_price": 100.0},
+        ]
+
+        # Deficit larger than a single position so the fallback name is needed too.
+        sells = await engine._generate_deficit_sells(
+            1500.0,
+            reason_kind="cash_deficit",
+            total_value=10000.0,
+            preloaded_positions=positions,
+            preloaded_securities_map=securities_map,
+            preloaded_symbol_scores={"FRESH.EU": 0.1, "STALE.EU": 0.1},
+            preloaded_symbol_prices={"FRESH.EU": 100.0, "STALE.EU": 100.0},
+        )
+
+        order = [s.symbol for s in sells]
+        # Fresh (non-cool-off) name is exhausted first; cool-off name only as fallback.
+        assert order[0] == "STALE.EU"
+        assert "FRESH.EU" in order
+
 
 class TestContrarianSizing:
     @pytest.mark.asyncio

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -339,8 +339,10 @@ class TestDeficitSellsSimulatedCash:
         assert "STALE.EU" in sold
 
     @pytest.mark.asyncio
-    async def test_cash_deficit_repair_falls_back_to_cooloff_names(self):
-        """Negative-balance repair exhausts fresh names first, then falls back to cool-off names."""
+    async def test_cash_deficit_repair_never_sells_cooloff_names(self):
+        """Negative-balance repair must not sell a cool-off name even if the deficit
+        isn't fully covered. A cool-off sell is a bad trade; better to leave a
+        residual deficit and let the next cycle act once the window expires."""
         import time
 
         two_days_ago = int(time.time()) - 2 * 86400
@@ -359,7 +361,8 @@ class TestDeficitSellsSimulatedCash:
             {"symbol": "STALE.EU", "quantity": 10, "current_price": 100.0},
         ]
 
-        # Deficit larger than a single position so the fallback name is needed too.
+        # Deficit larger than the one eligible position: the cool-off name must
+        # still never be sold to cover the remainder.
         sells = await engine._generate_deficit_sells(
             1500.0,
             reason_kind="cash_deficit",
@@ -370,10 +373,9 @@ class TestDeficitSellsSimulatedCash:
             preloaded_symbol_prices={"FRESH.EU": 100.0, "STALE.EU": 100.0},
         )
 
-        order = [s.symbol for s in sells]
-        # Fresh (non-cool-off) name is exhausted first; cool-off name only as fallback.
-        assert order[0] == "STALE.EU"
-        assert "FRESH.EU" in order
+        sold = {s.symbol for s in sells}
+        assert "FRESH.EU" not in sold  # cool-off name never sold, even under deficit
+        assert "STALE.EU" in sold  # only the eligible name is sold (partial repair)
 
     @pytest.mark.asyncio
     async def test_funding_rotation_blocks_same_side_and_allows_untraded(self):

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -285,6 +285,8 @@ class TestDeficitSellsSimulatedCash:
         """Build an engine whose db exposes a recent-trade map and cool-off settings."""
         db = MagicMock()
         db.get_latest_trades_for_symbols = AsyncMock(return_value=latest_trades)
+        # Fallback path for symbols absent from the bulk map: no trade history.
+        db.get_trades = AsyncMock(return_value=[])
         engine = RebalanceEngine(db=db)
         engine._db = db
         engine._currency = MagicMock()
@@ -372,6 +374,47 @@ class TestDeficitSellsSimulatedCash:
         # Fresh (non-cool-off) name is exhausted first; cool-off name only as fallback.
         assert order[0] == "STALE.EU"
         assert "FRESH.EU" in order
+
+    @pytest.mark.asyncio
+    async def test_funding_rotation_blocks_same_side_and_allows_untraded(self):
+        """Funding rotation also blocks a recent same-side sell, and never blocks an untraded name."""
+        import time
+
+        two_days_ago = int(time.time()) - 2 * 86400
+        engine = self._cooloff_engine(
+            {
+                # Sold 2 days ago -> same-side (15d) window still open -> blocked.
+                "RECENT_SELL.EU": {"side": "SELL", "executed_at": two_days_ago},
+                # No entry for UNTRADED.EU -> no history -> must remain sellable.
+            }
+        )
+
+        securities_map = {
+            "RECENT_SELL.EU": {
+                "symbol": "RECENT_SELL.EU", "currency": "EUR", "min_lot": 1, "allow_sell": 1, "user_multiplier": 0.3,
+            },
+            "UNTRADED.EU": {
+                "symbol": "UNTRADED.EU", "currency": "EUR", "min_lot": 1, "allow_sell": 1, "user_multiplier": 0.3,
+            },
+        }
+        positions = [
+            {"symbol": "RECENT_SELL.EU", "quantity": 10, "current_price": 100.0},
+            {"symbol": "UNTRADED.EU", "quantity": 10, "current_price": 100.0},
+        ]
+
+        sells = await engine._generate_deficit_sells(
+            500.0,
+            reason_kind="funding_rotation",
+            total_value=10000.0,
+            preloaded_positions=positions,
+            preloaded_securities_map=securities_map,
+            preloaded_symbol_scores={"RECENT_SELL.EU": 0.1, "UNTRADED.EU": 0.1},
+            preloaded_symbol_prices={"RECENT_SELL.EU": 100.0, "UNTRADED.EU": 100.0},
+        )
+
+        sold = {s.symbol for s in sells}
+        assert "RECENT_SELL.EU" not in sold  # same-side cool-off still open
+        assert "UNTRADED.EU" in sold  # no trade history -> allowed
 
 
 class TestContrarianSizing:


### PR DESCRIPTION
The funding/deficit sell path in rebalance_cash.py built TradeRecommendation
sells directly and never ran the cool-off check that the main recommendation
path enforces. This let the engine sell names it had just bought in order to
fund new strategic-preference buys, producing same-day round-trip churn well
inside the configured cool-off windows.

Funding-rotation sells now skip any holding still inside its cool-off window
outright. Negative-cash-balance repair prefers fresh names but falls back to
cool-off names as a last resort, so it can still avoid a margin-incurring
deficit when nothing else covers it.

Adds regression tests for both behaviours.